### PR TITLE
[23] обавлено API получения списка задач за период

### DIFF
--- a/__tests__/repositories/test_task_repository.py
+++ b/__tests__/repositories/test_task_repository.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 from unittest import TestCase
 from unittest.mock import create_autospec, patch
 
@@ -30,35 +30,23 @@ class TestTaskRepository(TestCase):
         # assert - должен вызваться метод add в Session с переданным task
         self.__session.add.assert_called_once_with(task)
 
-
-class TestTaskRepositoryGetByPeriod(TestCase):
-    __session: Session
-    __task_repository: TaskRepository
-
-    def setUp(self):
-        super().setUp()
-        self.__session = create_autospec(Session)
-        self.__task_repository = TaskRepository(
-            db_context=self.__session
-        )
-
     @patch("models.task_model.Task", autospec=True)
     def test_get_by_period(self, mock_task):
         # arrange
-        start_date = datetime(2023, 1, 1)
-        end_date = datetime(2023, 1, 31)
+        start_date = date(2023, 1, 1)
+        end_date = date(2023, 1, 31)
         tasks = [
             mock_task(
                 id=1,
                 title="Задача 1",
                 description="Описание задачи 1",
-                due_date=datetime(2023, 1, 15),
+                due_date=date(2023, 1, 15),
             ),
             mock_task(
                 id=2,
                 title="Задача 2",
                 description="Описание задачи 2",
-                due_date=datetime(2023, 1, 20),
+                due_date=date(2023, 1, 20),
             ),
         ]
         self.__session.query.return_value.filter.return_value.all.return_value = (

--- a/__tests__/services/test_task_service.py
+++ b/__tests__/services/test_task_service.py
@@ -1,15 +1,20 @@
-from datetime import date, timedelta
-from unittest import TestCase
+from datetime import date, datetime, timedelta, timezone
+from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import create_autospec, patch
 
 import pytest
 
+from models import Task
 from pydantic import ValidationError
 from repositories.task_repository import TaskRepository
 from schemas.pydantic.task_schema import (
     TaskPostRequestSchema,
 )
-from services.task_service import TaskService
+from services.task_service import (
+    MAX_TIMESTAMP,
+    MIN_TIMESTAMP,
+    TaskService,
+)
 
 
 class TestTaskService(TestCase):
@@ -128,3 +133,121 @@ class TestTaskService(TestCase):
             TaskPostRequestSchema(
                 title="title", description=123
             )
+
+
+class TestTaskServiceGetTasksByPeriod(
+    IsolatedAsyncioTestCase
+):
+    async def asyncSetUp(self):
+        self.task_repository = create_autospec(
+            TaskRepository, instance=True
+        )
+        self.task_service = TaskService(
+            task_repository=self.task_repository
+        )
+
+    async def test_get_tasks_by_period_valid(self):
+        # arrange
+        start_date = datetime(
+            2020, 1, 1, tzinfo=timezone.utc
+        ).timestamp()
+        end_date = datetime(
+            2020, 1, 31, tzinfo=timezone.utc
+        ).timestamp()
+        tasks = [
+            Task(
+                id=1,
+                title="Task 1",
+                description="Description 1",
+                due_date=datetime(
+                    2020, 1, 15, tzinfo=timezone.utc
+                ),
+            ),
+            Task(
+                id=2,
+                title="Task 2",
+                description="Description 2",
+                due_date=datetime(
+                    2020, 1, 20, tzinfo=timezone.utc
+                ),
+            ),
+        ]
+        self.task_repository.get_by_period.return_value = (
+            tasks
+        )
+
+        result = (
+            await self.task_service.get_tasks_by_period(
+                start_date, end_date
+            )
+        )
+
+        # act & assert
+        self.task_repository.get_by_period.assert_called_once_with(
+            datetime.fromtimestamp(
+                start_date, timezone.utc
+            ),
+            datetime.fromtimestamp(end_date, timezone.utc),
+        )
+        self.assertEqual(result, tasks)
+
+    async def test_get_tasks_by_period_invalid_start_date(
+        self,
+    ):
+        # arrange
+        start_date = (
+            MIN_TIMESTAMP - 10
+        )  # invalid start date
+        end_date = datetime(
+            2020, 1, 31, tzinfo=timezone.utc
+        ).timestamp()
+
+        # act & assert
+        with self.assertRaises(ValueError) as context:
+            await self.task_service.get_tasks_by_period(
+                start_date, end_date
+            )
+        self.assertIn(
+            "start_date вне допустимого диапазона",
+            str(context.exception),
+        )
+
+    async def test_get_tasks_by_period_invalid_end_date(
+        self,
+    ):
+        # arrange
+        end_date = MAX_TIMESTAMP + 10  # invalid end date
+        start_date = datetime(
+            2020, 1, 1, tzinfo=timezone.utc
+        ).timestamp()
+
+        # act & assert
+        with self.assertRaises(ValueError) as context:
+            await self.task_service.get_tasks_by_period(
+                start_date, end_date
+            )
+        self.assertIn(
+            "end_date вне допустимого диапазона",
+            str(context.exception),
+        )
+
+    async def test_get_tasks_by_period_start_date_greater_than_end_date(
+        self,
+    ):
+        # arrange
+        start_date = datetime(
+            2020, 2, 1, tzinfo=timezone.utc
+        ).timestamp()
+        end_date = datetime(
+            2020, 1, 1, tzinfo=timezone.utc
+        ).timestamp()
+
+        # act & assert
+        with self.assertRaises(ValueError) as context:
+            await self.task_service.get_tasks_by_period(
+                start_date, end_date
+            )
+        self.assertIn(
+            "start_date должна быть меньше end_date",
+            str(context.exception),
+        )

--- a/main.py
+++ b/main.py
@@ -18,12 +18,16 @@ app.include_router(task_router)
 
 
 @app.exception_handler(HTTPException)
-async def unicorn_exception_handler(
+async def http_exception_handler(
     request: Request, exc: HTTPException
 ):
     return JSONResponse(
-        status_code=500,
-        content={
-            "msg": f"Произошла ошибка на стороне сервера. Пожалуйста, попробуйте еще раз позже."
-        },
+        status_code=exc.status_code,
+        content=(
+            {"msg": exc.detail}
+            if exc.detail
+            else {
+                "msg": "Произошла ошибка на стороне сервера. Пожалуйста, попробуйте еще раз позже."
+            }
+        ),
     )

--- a/repositories/task_repository.py
+++ b/repositories/task_repository.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import date
+from typing import List
 
 from fastapi import Depends
 from sqlalchemy.orm import Session
@@ -23,8 +24,8 @@ class TaskRepository:
         return task
 
     def get_by_period(
-        self, start_date: datetime, end_date: datetime
-    ):
+        self, start_date: date, end_date: date
+    ) -> List[Task]:
         return (
             self.__db_context.query(Task)
             .filter(

--- a/repositories/task_repository.py
+++ b/repositories/task_repository.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
@@ -19,3 +21,15 @@ class TaskRepository:
         self.__db_context.commit()
         self.__db_context.refresh(task)
         return task
+
+    def get_by_period(
+        self, start_date: datetime, end_date: datetime
+    ):
+        return (
+            self.__db_context.query(Task)
+            .filter(
+                Task.due_date >= start_date,
+                Task.due_date <= end_date,
+            )
+            .all()
+        )

--- a/routers/v1/task_router.py
+++ b/routers/v1/task_router.py
@@ -10,6 +10,7 @@ from fastapi import (
 
 from schemas.pydantic.task_schema import (
     TaskPostRequestSchema,
+    TaskResponseSchema,
     TaskSchema,
 )
 from services.task_service import TaskService
@@ -34,23 +35,24 @@ async def create(
 
 @task_router.get(
     "/",
-    response_model=List[TaskSchema],
+    response_model=List[TaskResponseSchema],
     status_code=status.HTTP_200_OK,
 )
 async def get_tasks(
-    start_date: int = Query(
+    start_date: str = Query(
         ...,
-        description="Начальная дата в формате UNIX timestamp",
+        description="Начальная дата в формате даты (гггг-мм-дд)",
     ),
-    end_date: int = Query(
+    end_date: str = Query(
         ...,
-        description="Конечная дата в формате UNIX timestamp",
+        description="Конечная дата в формате даты (гггг-мм-дд)",
     ),
     task_service: TaskService = Depends(),
 ):
     try:
-        return await task_service.get_tasks_by_period(
+        tasks = await task_service.get_tasks_by_period(
             start_date, end_date
         )
+        return tasks
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))

--- a/routers/v1/task_router.py
+++ b/routers/v1/task_router.py
@@ -1,4 +1,12 @@
-from fastapi import APIRouter, Depends, status
+from typing import List
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Query,
+    status,
+)
 
 from schemas.pydantic.task_schema import (
     TaskPostRequestSchema,
@@ -22,3 +30,27 @@ async def create(
     task_service: TaskService = Depends(),
 ):
     return task_service.create(task)
+
+
+@task_router.get(
+    "/",
+    response_model=List[TaskSchema],
+    status_code=status.HTTP_200_OK,
+)
+async def get_tasks(
+    start_date: int = Query(
+        ...,
+        description="Начальная дата в формате UNIX timestamp",
+    ),
+    end_date: int = Query(
+        ...,
+        description="Конечная дата в формате UNIX timestamp",
+    ),
+    task_service: TaskService = Depends(),
+):
+    try:
+        return await task_service.get_tasks_by_period(
+            start_date, end_date
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))

--- a/schemas/pydantic/task_schema.py
+++ b/schemas/pydantic/task_schema.py
@@ -38,3 +38,10 @@ class TaskPostRequestSchema(BaseModel):
 
 class TaskSchema(TaskPostRequestSchema):
     id: int
+
+
+class TaskResponseSchema(BaseModel):
+    id: int
+    title: str
+    description: Optional[str] = None
+    due_date: Optional[date] = None

--- a/services/task_service.py
+++ b/services/task_service.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from fastapi import Depends
 
 from models.task_model import Task
@@ -5,6 +7,13 @@ from repositories.task_repository import TaskRepository
 from schemas.pydantic.task_schema import (
     TaskPostRequestSchema,
 )
+
+MIN_TIMESTAMP = datetime(
+    1970, 1, 2, tzinfo=timezone.utc
+).timestamp()
+MAX_TIMESTAMP = datetime(
+    2038, 1, 18, tzinfo=timezone.utc
+).timestamp()
 
 
 class TaskService:
@@ -24,4 +33,36 @@ class TaskService:
                 description=task_content.description,
                 due_date=task_content.due_date,
             )
+        )
+
+    async def get_tasks_by_period(
+        self, start_date: int, end_date: int
+    ):
+        if (
+            start_date < MIN_TIMESTAMP
+            or start_date > MAX_TIMESTAMP
+        ):
+            raise ValueError(
+                "start_date вне допустимого диапазона"
+            )
+        if (
+            end_date < MIN_TIMESTAMP
+            or end_date > MAX_TIMESTAMP
+        ):
+            raise ValueError(
+                "end_date вне допустимого диапазона"
+            )
+        start_date_converted = datetime.fromtimestamp(
+            start_date, timezone.utc
+        )
+        end_date_converted = datetime.fromtimestamp(
+            end_date, timezone.utc
+        )
+        if start_date_converted >= end_date_converted:
+            raise ValueError(
+                "start_date должна быть меньше end_date"
+            )
+
+        return self.__task_repository.get_by_period(
+            start_date_converted, end_date_converted
         )


### PR DESCRIPTION
## Описание Фичи: Получение списка задач за выбранный период

### Цель:
Реализация API эндпоинта для получения списка задач, созданных в определенный временной диапазон.

### Основные изменения:
- Добавлен новый эндпоинт `/tasks` в `task_router`, который принимает GET запросы с параметрами `start_date` и `end_date` в формате UNIX timestamp.
- Реализована логика в `TaskService` для обработки запросов на получение задач, включая валидацию дат и проверку, что `start_date` меньше `end_date`.
- В `TaskRepository` добавлен метод `get_by_period`, который извлекает задачи из базы данных, соответствующие заданному временному диапазону.
- Написаны тесты для проверки корректности работы новой фичи на уровне репозитория и сервиса, а также для проверки валидации входных данных.

Вывод pytest --cov .:
![image](https://github.com/vpo-tusur/todo-api/assets/113753508/6ab6b302-652e-4fb7-b24c-3a2c71cf3c10)

