### PR TITLE
[21] Реализовано получение списка задач за определённую дату

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -49,6 +49,13 @@
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "version": "==0.4.6"
+        },
         "fastapi": {
             "hashes": [
                 "sha256:5df913203c482f820d31f48e635e022f8cbfe7350e4830ef05a3163925b1addc",
@@ -173,19 +180,19 @@
         },
         "idna": {
             "hashes": [
-                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
-                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
+                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.6"
+            "version": "==3.7"
         },
         "mako": {
             "hashes": [
-                "sha256:2a0c8ad7f6274271b3bb7467dd37cf9cc6dab4bc19cb69a4ef10669402de698e",
-                "sha256:32a99d70754dfce237019d17ffe4a282d2d3351b9c476e90d8a60e63f133b80c"
+                "sha256:5324b88089a8978bf76d1629774fcc2f1c07b82acdf00f4c5dd8ceadfffc4b40",
+                "sha256:e16c01d9ab9c11f7290eef1cfefc093fb5a45ee4a3da09e2fec2e4d1bae54e73"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.3.2"
+            "version": "==1.3.3"
         },
         "markupsafe": {
             "hashes": [
@@ -518,42 +525,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==0.29.0"
         },
-        "uvloop": {
-            "hashes": [
-                "sha256:0246f4fd1bf2bf702e06b0d45ee91677ee5c31242f39aab4ea6fe0c51aedd0fd",
-                "sha256:02506dc23a5d90e04d4f65c7791e65cf44bd91b37f24cfc3ef6cf2aff05dc7ec",
-                "sha256:13dfdf492af0aa0a0edf66807d2b465607d11c4fa48f4a1fd41cbea5b18e8e8b",
-                "sha256:2693049be9d36fef81741fddb3f441673ba12a34a704e7b4361efb75cf30befc",
-                "sha256:271718e26b3e17906b28b67314c45d19106112067205119dddbd834c2b7ce797",
-                "sha256:2df95fca285a9f5bfe730e51945ffe2fa71ccbfdde3b0da5772b4ee4f2e770d5",
-                "sha256:31e672bb38b45abc4f26e273be83b72a0d28d074d5b370fc4dcf4c4eb15417d2",
-                "sha256:34175c9fd2a4bc3adc1380e1261f60306344e3407c20a4d684fd5f3be010fa3d",
-                "sha256:45bf4c24c19fb8a50902ae37c5de50da81de4922af65baf760f7c0c42e1088be",
-                "sha256:472d61143059c84947aa8bb74eabbace30d577a03a1805b77933d6bd13ddebbd",
-                "sha256:47bf3e9312f63684efe283f7342afb414eea4d3011542155c7e625cd799c3b12",
-                "sha256:492e2c32c2af3f971473bc22f086513cedfc66a130756145a931a90c3958cb17",
-                "sha256:4ce6b0af8f2729a02a5d1575feacb2a94fc7b2e983868b009d51c9a9d2149bef",
-                "sha256:5138821e40b0c3e6c9478643b4660bd44372ae1e16a322b8fc07478f92684e24",
-                "sha256:5588bd21cf1fcf06bded085f37e43ce0e00424197e7c10e77afd4bbefffef428",
-                "sha256:570fc0ed613883d8d30ee40397b79207eedd2624891692471808a95069a007c1",
-                "sha256:5a05128d315e2912791de6088c34136bfcdd0c7cbc1cf85fd6fd1bb321b7c849",
-                "sha256:5daa304d2161d2918fa9a17d5635099a2f78ae5b5960e742b2fcfbb7aefaa593",
-                "sha256:5f17766fb6da94135526273080f3455a112f82570b2ee5daa64d682387fe0dcd",
-                "sha256:6e3d4e85ac060e2342ff85e90d0c04157acb210b9ce508e784a944f852a40e67",
-                "sha256:7010271303961c6f0fe37731004335401eb9075a12680738731e9c92ddd96ad6",
-                "sha256:7207272c9520203fea9b93843bb775d03e1cf88a80a936ce760f60bb5add92f3",
-                "sha256:78ab247f0b5671cc887c31d33f9b3abfb88d2614b84e4303f1a63b46c046c8bd",
-                "sha256:7b1fd71c3843327f3bbc3237bedcdb6504fd50368ab3e04d0410e52ec293f5b8",
-                "sha256:8ca4956c9ab567d87d59d49fa3704cf29e37109ad348f2d5223c9bf761a332e7",
-                "sha256:91ab01c6cd00e39cde50173ba4ec68a1e578fee9279ba64f5221810a9e786533",
-                "sha256:cd81bdc2b8219cb4b2556eea39d2e36bfa375a2dd021404f90a62e44efaaf957",
-                "sha256:da8435a3bd498419ee8c13c34b89b5005130a476bda1d6ca8cfdde3de35cd650",
-                "sha256:de4313d7f575474c8f5a12e163f6d89c0a878bc49219641d49e6f1444369a90e",
-                "sha256:e27f100e1ff17f6feeb1f33968bc185bf8ce41ca557deee9d9bbbffeb72030b7",
-                "sha256:f467a5fd23b4fc43ed86342641f3936a68ded707f4627622fa3f82a120e18256"
-            ],
-            "version": "==0.19.0"
-        },
         "watchfiles": {
             "hashes": [
                 "sha256:02b73130687bc3f6bb79d8a170959042eb56eb3a42df3671c79b428cd73f17cc",
@@ -757,6 +728,13 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "version": "==0.4.6"
         },
         "coverage": {
             "extras": [

--- a/__tests__/services/test_task_service.py
+++ b/__tests__/services/test_task_service.py
@@ -176,9 +176,7 @@ class TestTaskService(TestCase):
             )
 
 
-class TestTaskServiceGetTasksByPeriod(
-    IsolatedAsyncioTestCase
-):
+class TestTaskGetService(IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.task_repository = create_autospec(
             TaskRepository, instance=True
@@ -254,6 +252,7 @@ class TestTaskServiceGetTasksByPeriod(
         end_date = (
             "2020-01-01"  # Та же дата, что и start_date
         )
+
         self.task_repository.get_by_period.return_value = []
 
         # act
@@ -296,5 +295,90 @@ class TestTaskServiceGetTasksByPeriod(
         # assert
         self.task_repository.get_by_period.assert_called_once_with(
             date(1984, 1, 1), date(1984, 1, 31)
+        )
+        self.assertEqual(result, [])
+
+    async def test_get_tasks_by_date_valid(self):
+        # arrange
+        test_date = date.today().isoformat()
+        tasks = [
+            Task(
+                id=1,
+                title="Task 1",
+                description="Description 1",
+                due_date=date.today(),
+            ),
+            Task(
+                id=2,
+                title="Task 2",
+                description="Description 2",
+                due_date=date.today(),
+            ),
+        ]
+        self.task_repository.get_by_period.return_value = (
+            tasks
+        )
+
+        # act
+        result = await self.task_service.get_tasks_by_date(
+            test_date
+        )
+
+        # assert
+        self.task_repository.get_by_period.assert_called_once_with(
+            date.today(), date.today()
+        )
+        self.assertEqual(result, tasks)
+
+    async def test_get_tasks_by_date_incorrect_format(self):
+        # arrange
+        incorrect_date = "не дата"  # Некорректный формат
+
+        # act & assert
+        with self.assertRaises(ValueError):
+            await self.task_service.get_tasks_by_date(
+                incorrect_date
+            )
+
+    async def test_get_tasks_by_date_no_date_provided_uses_today(
+        self,
+    ):
+        # arrange
+        tasks = [
+            Task(
+                id=1,
+                title="Task Today 1",
+                description="Description Today 1",
+                due_date=date.today(),
+            ),
+        ]
+        self.task_repository.get_by_period.return_value = (
+            tasks
+        )
+
+        # act
+        result = await self.task_service.get_tasks_by_date(
+            None
+        )
+
+        # assert
+        self.task_repository.get_by_period.assert_called_once_with(
+            date.today(), date.today()
+        )
+        self.assertEqual(result, tasks)
+
+    async def test_get_tasks_by_date_no_tasks_found(self):
+        # arrange
+        test_date = "1984-01-01"
+        self.task_repository.get_by_period.return_value = []
+
+        # act
+        result = await self.task_service.get_tasks_by_date(
+            test_date
+        )
+
+        # assert
+        self.task_repository.get_by_period.assert_called_once_with(
+            date(1984, 1, 1), date(1984, 1, 1)
         )
         self.assertEqual(result, [])

--- a/services/task_service.py
+++ b/services/task_service.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import List
+from typing import List, Optional
 
 from dateutil import parser, tz
 from fastapi import Depends
@@ -55,6 +55,18 @@ class TaskService:
         return self.__task_repository.get_by_period(
             start_date, end_date
         )
+
+    async def get_tasks_by_date(
+        self, date_str: Optional[str]
+    ) -> List[Task]:
+        if date_str is None:
+            date_str = date.today().isoformat()
+        target_date = parse_date(date_str)
+
+        tasks = self.__task_repository.get_by_period(
+            target_date, target_date
+        )
+        return tasks
 
 
 def parse_date(date_str: str) -> date:


### PR DESCRIPTION
## Описание Фичи: Получение списка задач на день
### Цель:
Реализация API эндпоинта для получения списка задач, созданных в определенный день.

### Основные изменения:
- Модифицирован эндпоинт `/tasks` в `task_router`, который поддерживает GET запросы. Эндпоинт принимает параметры `date` для получения задач на конкретный день, или `start_date` и `end_date` для задания временного диапазона. Параметры даты принимаются в формате `YYYY-MM-DD`.
- В `TaskService` реализован метод `get_tasks_by_date` для обработки запросов на получение задач. Метод `get_tasks_by_date` используется для запросов на конкретную дату.
- Написаны тесты для проверки корректности работы новой функциональности на уровне сервиса.

### Вывод pytest --cov . :
![image](https://github.com/vpo-tusur/todo-api/assets/113753508/28888c26-cc2a-4b5d-a162-99b1640c1cdf)
