### PR TITLE
[19] Исправил некорректное поведение при отсутсвуещем description в запросе

### DIFF
--- a/routers/v1/task_router.py
+++ b/routers/v1/task_router.py
@@ -67,6 +67,7 @@ async def get_tasks(
     response_model=TaskPutRequestSchema,
     status_code=status.HTTP_200_OK,
 )
+@task_router.put("/{task_id}")
 async def update(
     task_id: int,
     task: TaskPutRequestSchema,

--- a/routers/v1/task_router.py
+++ b/routers/v1/task_router.py
@@ -67,7 +67,6 @@ async def get_tasks(
     response_model=TaskPutRequestSchema,
     status_code=status.HTTP_200_OK,
 )
-@task_router.put("/{task_id}")
 async def update(
     task_id: int,
     task: TaskPutRequestSchema,

--- a/schemas/pydantic/task_schema.py
+++ b/schemas/pydantic/task_schema.py
@@ -46,33 +46,6 @@ class TaskPutRequestSchema(BaseModel):
     description: Annotated[
         Optional[str],
         StringConstraints(
-            strip_whitespace=True, min_length=1
-        ),
-    ] = Field(description="Описание задачи")
-    due_date: Optional[date] = Field(
-        description="День задачи", default=date.today()
-    )
-
-    @field_validator("due_date")
-    @classmethod
-    def validate_date(cls, v: date) -> date:
-        if v < date.today():
-            raise ValueError(
-                f"Date should be greater or equal than {date.today()}"
-            )
-        return v
-
-
-class TaskPutRequestSchema(BaseModel):
-    title: Annotated[
-        str,
-        StringConstraints(
-            strip_whitespace=True, min_length=1
-        ),
-    ] = Field(description="Название задачи")
-    description: Annotated[
-        Optional[str],
-        StringConstraints(
             strip_whitespace=True
         ),
     ] = Field(description="Описание задачи", default="")

--- a/schemas/pydantic/task_schema.py
+++ b/schemas/pydantic/task_schema.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Optional
+from typing import Any, Dict, Optional, Union
 
 from typing_extensions import Annotated
 
@@ -63,6 +63,33 @@ class TaskPutRequestSchema(BaseModel):
         return v
 
 
+class TaskPutRequestSchema(BaseModel):
+    title: Annotated[
+        str,
+        StringConstraints(
+            strip_whitespace=True, min_length=1
+        ),
+    ] = Field(description="Название задачи")
+    description: Annotated[
+        Optional[str],
+        StringConstraints(
+            strip_whitespace=True
+        ),
+    ] = Field(description="Описание задачи", default="")
+    due_date: Optional[date] = Field(
+        description="День задачи", default=date.today()
+    )
+
+    @field_validator("due_date")
+    @classmethod
+    def validate_dob(cls, v: date) -> date:
+        if v < date.today():
+            raise ValueError(
+                f"Date should be greater or equal than {date.today()}"
+            )
+        return v
+
+
 class TaskSchema(TaskPostRequestSchema):
     id: int
 
@@ -72,3 +99,13 @@ class TaskResponseSchema(BaseModel):
     title: str
     description: Optional[str] = None
     due_date: Optional[date] = None
+
+
+class ServiceResponse(BaseModel):
+    content: Union[
+        Dict[str, Any],
+        Annotated[str, StringConstraints(min_length=1)],
+    ] = Field(description="Контент ответа")
+    status: Annotated[int, Annotated[int, Field(gt=0)]] = (
+        Field(description="Статус ответа")
+    )

--- a/schemas/pydantic/task_schema.py
+++ b/schemas/pydantic/task_schema.py
@@ -45,9 +45,7 @@ class TaskPutRequestSchema(BaseModel):
     ] = Field(description="Название задачи")
     description: Annotated[
         Optional[str],
-        StringConstraints(
-            strip_whitespace=True
-        ),
+        StringConstraints(strip_whitespace=True),
     ] = Field(description="Описание задачи", default="")
     due_date: Optional[date] = Field(
         description="День задачи", default=date.today()

--- a/schemas/pydantic/task_schema.py
+++ b/schemas/pydantic/task_schema.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Any, Dict, Optional, Union
+from typing import Optional
 
 from typing_extensions import Annotated
 
@@ -82,7 +82,7 @@ class TaskPutRequestSchema(BaseModel):
 
     @field_validator("due_date")
     @classmethod
-    def validate_dob(cls, v: date) -> date:
+    def validate_date(cls, v: date) -> date:
         if v < date.today():
             raise ValueError(
                 f"Date should be greater or equal than {date.today()}"
@@ -99,13 +99,3 @@ class TaskResponseSchema(BaseModel):
     title: str
     description: Optional[str] = None
     due_date: Optional[date] = None
-
-
-class ServiceResponse(BaseModel):
-    content: Union[
-        Dict[str, Any],
-        Annotated[str, StringConstraints(min_length=1)],
-    ] = Field(description="Контент ответа")
-    status: Annotated[int, Annotated[int, Field(gt=0)]] = (
-        Field(description="Статус ответа")
-    )


### PR DESCRIPTION
Теперь если в поле `description` передана пустая строка или поле не задано вовсе, подставляется пустая строка под значение параметра `description`.