### PR TITLE
[22] Pеализовано получение списка задач за одну неделю

### DIFF
--- a/routers/v1/task_router.py
+++ b/routers/v1/task_router.py
@@ -54,10 +54,13 @@ async def get_tasks(
         None,
         description="Конечная дата в формате (гггг-мм-дд)",
     ),
+    week: Optional[bool] = Query(
+        None,
+        description="Если True, возвращает задачи за неделю начиная с указанной date.",
+    ),
     task_service: TaskService = Depends(),
 ):
     try:
-        tasks = []
         if date is not None and (
             start_date is not None or end_date is not None
         ):
@@ -66,22 +69,23 @@ async def get_tasks(
                 detail="Запрос не может одновременно содержать 'date' и 'start_date'/'end_date'. "
                 "Пожалуйста, укажите только один из этих параметров.",
             )
-        if date is not None:
-            tasks = await task_service.get_tasks_by_date(
+
+        if week and date:
+            return await task_service.get_tasks_for_week(
                 date
             )
-        elif (
-            start_date is not None and end_date is not None
-        ):
-            tasks = await task_service.get_tasks_by_period(
+        elif date:
+            return await task_service.get_tasks_by_date(
+                date
+            )
+        elif start_date and end_date:
+            return await task_service.get_tasks_by_period(
                 start_date, end_date
             )
         else:
-            tasks = await task_service.get_tasks_by_date(
+            return await task_service.get_tasks_by_date(
                 None
             )
-
-        return tasks
     except ValueError:
         raise HTTPException(
             status_code=422,

--- a/services/task_service.py
+++ b/services/task_service.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, timedelta
 from typing import List, Optional
 
 from dateutil import parser, tz
@@ -67,6 +67,16 @@ class TaskService:
             target_date, target_date
         )
         return tasks
+
+    async def get_tasks_for_week(
+        self, date_str: str
+    ) -> List[Task]:
+        start_date = parse_date(date_str)
+        end_date = start_date + timedelta(days=6)
+
+        return await self.get_tasks_by_period(
+            start_date.isoformat(), end_date.isoformat()
+        )
 
 
 def parse_date(date_str: str) -> date:


### PR DESCRIPTION
## Описание Фичи: Получение списка задач на неделю

### Цель:
Расширение функциональности API для получения списка задач за неделю.

### Основные изменения:
- **Модификация существующего эндпоинта `/tasks`:** Теперь он поддерживает дополнительный параметр `week`, который позволяет получать задачи за неделю, начиная с указанной даты `date`.
- **Сервис `TaskService`:** Добавлен новый метод `get_tasks_for_week`, который обрабатывает логику получения задач за неделю.
- **Тестирование:** Реализованы unit-тесты для новых методов в `TaskService` и проверки измененной логики в роутере, обеспечивая покрытие нового функционала тестами.

Вывод pytest --cov .:
![image_2024-04-18_19-29-31](https://github.com/vpo-tusur/todo-api/assets/113753508/d12e4f64-0d3b-4cd3-95f0-48499bbf1ff7)