### PR TITLE
[23] Исправление обработчика запросов `get_tasks`

### DIFF
--- a/routers/v1/task_router.py
+++ b/routers/v1/task_router.py
@@ -58,6 +58,7 @@ async def get_tasks(
     task_service: TaskService = Depends(),
 ):
     try:
+        # Проверка на наличие одновременно 'date' и 'start_date'/'end_date'
         if date is not None and (
             start_date is not None or end_date is not None
         ):
@@ -67,6 +68,31 @@ async def get_tasks(
                 "Пожалуйста, укажите только один из этих параметров.",
             )
 
+        # Проверка на наличие одновременно 'week' и 'start_date'/'end_date'
+        if week and (
+            start_date is not None or end_date is not None
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="Запрос не может одновременно содержать 'week' и 'start_date'/'end_date'. "
+                "Пожалуйста, укажите только один из этих параметров.",
+            )
+
+        # Проверка, что 'end_date' не может быть передан без 'start_date'
+        if end_date and not start_date:
+            raise HTTPException(
+                status_code=422,
+                detail="Поле 'start_date' обязательно при наличии 'end_date'.",
+            )
+
+        # Проверка, что 'start_date' не может быть передан без 'end_date'
+        if start_date and not end_date:
+            raise HTTPException(
+                status_code=422,
+                detail="Поле 'end_date' обязательно при наличии 'start_date'.",
+            )
+
+        # Логика обработки запросов
         if week and date:
             return await task_service.get_tasks_for_week(
                 date


### PR DESCRIPTION
## Описание изменений

В этом PR внесены исправления в эндпоинт `get_tasks` для учета следующих замечаний от тестировщика:

1. **Конфликт параметров `week` и `start_date`/`end_date`:**
   - **Проблема:** Если параметр `week` задан как `True`, и `start_date` или `end_date` тоже заданы, сервер возвращает 200 с задачами за неделю, начиная с текущей даты.
   - **Исправление:** Добавлена проверка, чтобы запрос с параметрами `week` и `start_date`/`end_date` возвращал ошибку 400 с сообщением "Запрос не может одновременно содержать 'week' и 'start_date'/'end_date'. Пожалуйста, укажите только один из этих параметров."

2. **Отсутствие параметра `start_date` при наличии `end_date`:**
   - **Проблема:** Если `end_date` задан, а `start_date` не задан, сервер возвращает 200 с задачами на текущую дату.
   - **Исправление:** Добавлена проверка, чтобы запрос с `end_date` без `start_date` возвращал ошибку 422 с сообщением "Поле 'start_date' обязательно при наличии 'end_date'."

3. **Отсутствие параметра `end_date` при наличии `start_date`:**
   - **Проблема:** Если `start_date` задан, а `end_date` не задан, сервер возвращает 200 с задачами на текущую дату.
   - **Исправление:** Добавлена проверка, чтобы запрос с `start_date` без `end_date` возвращал ошибку 422 с сообщением "Поле 'end_date' обязательно при наличии 'start_date'."
